### PR TITLE
Fix bot crashing when response is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,8 @@ client.on("message", async message => {
             break;
     }
 
+    if (response === null) return;
+
     if (response.error) {
         message.channel.send(response.error.message);
         return;


### PR DESCRIPTION
There have been cases of the bot crashing when the response is still set to `null` after the switch statement.

This simply adds an early return to make sure the bot keeps running. 👍 