### PR TITLE
[Feature] Delete (Bot response) Via Reaction

### DIFF
--- a/src/deleteViaReaction.js
+++ b/src/deleteViaReaction.js
@@ -1,27 +1,32 @@
+async function deleteViaReaction(
+    commandMessage,
+    responseEmbed,
+    responseUrlMessage,
+    client
+) {
+    // Create the initial reaction
+    const reaction = await responseEmbed.react("❌");
 
-async function deleteViaReaction(commandMessage, responseMessage, client) {
-    const reactionFilter = (reaction, user) => {
-        // Type coercion is on purpose.
-        if (reaction.emoji.id != "472490448016113675")
-            return false;
+    // Wait 20 seconds before giving up
+    const reactionFilter = (reaction, user) =>
+        reaction.emoji.name === "❌" && user.id === commandMessage.author.id;
+    const reactionCollector = responseEmbed.createReactionCollector(
+        reactionFilter,
+        { time: 20000 }
+    );
 
-        const member = responseMessage.guild.fetchMember(user)
-
-        // hasPermission docs: https://discord.js.org/#/docs/main/stable/class/GuildMember?scrollTo=hasPermission
-        // Check to see if they have delete messages permission or is the user who issued the command.
-        if (!(member.hasPermission("MANAGE_MESSAGES", false, true, true)) || user.id !== commandMessage.author.id)
-            return false;
-
-        return true;
-    };
-
-    const flippityFlappingFuck = await responseMessage.react("472490448016113675");
-    // Wait 2 minutes before giving up
-    const reactionCollector = responseMessage.createReactionCollector(reactionFilter, { time: 2 * 60 * 60 });
     // Delete the message if we 'collect' (Filter is successful)
-    reactionCollector.once("collect", reaction => { reaction.message.delete() });
+    reactionCollector.once("collect", reaction => {
+        reaction.message.delete();
+        if (responseUrlMessage) responseUrlMessage.delete();
+    });
+
     // When the time is up, remove the bots reaction to the post
-    reactionCollector.once("end", collected => { flippityFlappingFuck.remove(client.user) } );
+    reactionCollector.once("end", () => {
+        if (!reaction.message.deleted) {
+            reaction.remove(client.user);
+        }
+    });
 }
 
 module.exports = deleteViaReaction;

--- a/src/deleteViaReaction.js
+++ b/src/deleteViaReaction.js
@@ -1,0 +1,27 @@
+
+async function deleteViaReaction(commandMessage, responseMessage, client) {
+    const reactionFilter = (reaction, user) => {
+        // Type coercion is on purpose.
+        if (reaction.emoji.id != "472490448016113675")
+            return false;
+
+        const member = responseMessage.guild.fetchMember(user)
+
+        // hasPermission docs: https://discord.js.org/#/docs/main/stable/class/GuildMember?scrollTo=hasPermission
+        // Check to see if they have delete messages permission or is the user who issued the command.
+        if (!(member.hasPermission("MANAGE_MESSAGES", false, true, true)) || user.id !== commandMessage.author.id)
+            return false;
+
+        return true;
+    };
+
+    const flippityFlappingFuck = await responseMessage.react("472490448016113675");
+    // Wait 2 minutes before giving up
+    const reactionCollector = responseMessage.createReactionCollector(reactionFilter, { time: 2 * 60 * 60 });
+    // Delete the message if we 'collect' (Filter is successful)
+    reactionCollector.once("collect", reaction => { reaction.message.delete() });
+    // When the time is up, remove the bots reaction to the post
+    reactionCollector.once("end", collected => { flippityFlappingFuck.remove(client.user) } );
+}
+
+module.exports = deleteViaReaction;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const studio = require("./studio");
 
 const client = new Discord.Client();
 
-const deleteViaReaction = require("./deleteViaReaction")
+const deleteViaReaction = require("./deleteViaReaction");
 
 // Use exclamation mark as the default prefix
 const prefix = process.env.PREFIX || "!";
@@ -95,11 +95,12 @@ client.on("message", async message => {
         return;
     }
 
+    let replyUrl;
     if (response.author && response.author.url) {
-        message.channel.send(`<${response.author.url}>`);
+        replyUrl = message.channel.send(`<${response.author.url}>`);
     }
 
-    const reply = message.channel.send({
+    const replyEmbed = message.channel.send({
         embed: {
             ...response,
             color: 3447003
@@ -107,7 +108,12 @@ client.on("message", async message => {
     });
 
     if (command !== "help") {
-        deleteViaReaction(message, reply, client)
+        deleteViaReaction(
+            message,
+            await replyEmbed,
+            replyUrl ? await replyUrl : replyUrl,
+            client
+        );
     }
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ const studio = require("./studio");
 
 const client = new Discord.Client();
 
+const deleteViaReaction = require("./deleteViaReaction")
+
 // Use exclamation mark as the default prefix
 const prefix = process.env.PREFIX || "!";
 
@@ -97,12 +99,16 @@ client.on("message", async message => {
         message.channel.send(`<${response.author.url}>`);
     }
 
-    message.channel.send({
+    const reply = message.channel.send({
         embed: {
             ...response,
             color: 3447003
         }
     });
+
+    if (command !== "help") {
+        deleteViaReaction(message, reply, client)
+    }
 });
 
 const help = {


### PR DESCRIPTION
This features makes the bot react to all commands (except help) with (currently) the FlippityFlappingFuck emoji. If the user who issued the command, or a user with the manage messages permissions (and as such, the capability to delete messages) also reacts with the same emoji, it will delete the response message.

The user has 2 minutes (give or take some latency) to react to the response before the bot assumes that the response is to stay. At that point it will remove the reaction it added.
If the user *does* react within 2 minutes, the message will simply be deleted.

This is handled by the `ReactionCollector` of discord.js. One (minor?) side effect is that I don't try to stop the collector, so in the event that the message is deleted almost immediately, there may be up to a 2 minute period where the `ReactionCollector` watches and attempts to filter any reactions.
Depending on how the `ReactionCollector` handles it, the reaction filter funcmay need to be adjusted to ensure that the reaction is on the command message. This shouldn't be an issue though.