### PR TITLE
spoiler continues to exist when is cut in the middle by `shorten`.

### DIFF
--- a/src/discordMessage.js
+++ b/src/discordMessage.js
@@ -2,9 +2,7 @@ const TurndownService = require("turndown");
 const turndownService = new TurndownService();
 const anilistLogo = "https://anilist.co/img/logo_al.png";
 
-const pipe = (op1, op2) => arg => op2(op1(arg));
-
-const removeSpoilers = str => str.replace(/<span[^>]*>.*<\/span>/g, "");
+turndownService.remove("span");
 
 const shorten = str => {
     const markdown = turndownService.turndown(str);
@@ -33,10 +31,7 @@ const discordMessage = ({
         thumbnail: {
             url: imageUrl
         },
-        description: pipe(
-            removeSpoilers,
-            shorten
-        )(description),
+        description: shorten(description),
         footer: {
             text: footer
         }


### PR DESCRIPTION
I used the https://anilist.co/character/17706 entry to debug and test the feature

appearance on the site:
![image](https://user-images.githubusercontent.com/30394812/118413681-3e8ba700-b6a9-11eb-9ae6-e41ae58150fb.png)

output in the current state of the bot:
![image](https://user-images.githubusercontent.com/30394812/118413715-6975fb00-b6a9-11eb-97f7-7b6c7605d88a.png)

expected output:
![image](https://user-images.githubusercontent.com/30394812/118413737-74c92680-b6a9-11eb-8588-62733486a831.png)

I thought that the [`remove` function in turndown](https://github.com/domchristie/turndown/blob/fc0d49fbc2178b04acb46243289eb58e4e48396f/README.md#removefilter) could replace the [current `removeSpoilers` function](https://github.com/AniList/discord-search-bot/blob/837ab34695bc121adcb8922a6aa60c0ca65f4988/src/discordMessage.js#L7) since it fully meets our needs.